### PR TITLE
feat: VFilterBox 이벤트 파라미터 전달 #23

### DIFF
--- a/src/components/pivottable-ui/VDragAndDropCell.vue
+++ b/src/components/pivottable-ui/VDragAndDropCell.vue
@@ -17,12 +17,16 @@
         :open="openStatus?.[item]"
         :unSelectedFilterValues="valueFilter?.[item]"
         :attributeName="item"
-        :attributeValues="allFilters[item]"
-        :zIndex="zIndices[item]"
+        :attributeValues="allFilters?.[item]"
+        :zIndex="zIndices?.[item]"
         :hideDropDownForUnused="hideDropDownForUnused"
-        @update:zIndexOfFilterBox="$emit('update:zIndexOfFilterBox')"
-        @update:unselectedFilterValues="$emit('update:unselectedFilterValues')"
-        @update:openStatusOfFilterBox="$emit('update:unselectedFilterValues')"
+        @update:zIndexOfFilterBox="$emit('update:zIndexOfFilterBox', $event)"
+        @update:unselectedFilterValues="
+          $emit('update:unselectedFilterValues', $event)
+        "
+        @update:openStatusOfFilterBox="
+          $emit('update:openStatusOfFilterBox', $event)
+        "
       >
         <template #pvtAttr="{ attrName }">
           {{ attrName }}

--- a/src/components/pivottable-ui/VDraggableAttribute.vue
+++ b/src/components/pivottable-ui/VDraggableAttribute.vue
@@ -11,8 +11,10 @@
         :filterBoxKey="attributeName"
         :filterBoxValues="attributeValues"
         :zIndex="zIndex"
-        @update:zIndexOfFilterBox="$emit('update:zIndexOfFilterBox')"
-        @update:unselectedFilterValues="$emit('update:unselectedFilterValues')"
+        @update:zIndexOfFilterBox="$emit('update:zIndexOfFilterBox', $event)"
+        @update:unselectedFilterValues="
+          $emit('update:unselectedFilterValues', $event)
+        "
       >
       </VFilterBox>
     </span>
@@ -64,7 +66,10 @@ const props = defineProps({
 })
 
 const toggleFilterBox = () => {
-  emit('update:openStatusOfFilterBox', props.attributeName)
+  emit('update:openStatusOfFilterBox', {
+    key: props.attributeName,
+    value: !props.open
+  })
 }
 
 const hideDropDown = computed(

--- a/src/components/pivottable-ui/VPivottableUi.vue
+++ b/src/components/pivottable-ui/VPivottableUi.vue
@@ -14,10 +14,13 @@
           :attributeNames="unusedAttrs"
           :allFilters="allFilters"
           :valueFilter="state.valueFilter"
+          :restrictedFromDragDrop="state.restrictedFromDragDrop"
           :fixedFromDragDrop="state.fixedFromDragDrop"
           :hideFilterBoxOfUnusedAttributes="
             state.hideFilterBoxOfUnusedAttributes
           "
+          :zIndices="state.zIndices"
+          :openStatus="state.openStatus"
           @update:zIndexOfFilterBox="onMoveFilterBoxToTop"
           @update:unselectedFilterValues="onUpdateValueFilter"
           @update:openStatusOfFilterBox="onUpdateOpenStatus"
@@ -51,10 +54,13 @@
           :attributeNames="colAttrs"
           :allFilters="allFilters"
           :valueFilter="state.valueFilter"
+          :restrictedFromDragDrop="state.restrictedFromDragDrop"
           :fixedFromDragDrop="state.fixedFromDragDrop"
           :hideFilterBoxOfUnusedAttributes="
             state.hideFilterBoxOfUnusedAttributes
           "
+          :zIndices="state.zIndices"
+          :openStatus="state.openStatus"
           @update:zIndexOfFilterBox="onMoveFilterBoxToTop"
           @update:unselectedFilterValues="onUpdateValueFilter"
           @update:openStatusOfFilterBox="onUpdateOpenStatus"
@@ -72,10 +78,13 @@
           :attributeNames="rowAttrs"
           :allFilters="allFilters"
           :valueFilter="state.valueFilter"
+          :restrictedFromDragDrop="state.restrictedFromDragDrop"
           :fixedFromDragDrop="state.fixedFromDragDrop"
           :hideFilterBoxOfUnusedAttributes="
             state.hideFilterBoxOfUnusedAttributes
           "
+          :zIndices="state.zIndices"
+          :openStatus="state.openStatus"
           @update:zIndexOfFilterBox="onMoveFilterBoxToTop"
           @update:unselectedFilterValues="onUpdateValueFilter"
           @update:openStatusOfFilterBox="onUpdateOpenStatus"
@@ -216,10 +225,10 @@ const onMoveFilterBoxToTop = ({ attribute }) => {
     [attribute]: state.value.maxZIndex
   })
 }
-const onUpdateValueFilter = ({ attribute, valueFilter }) => {
+const onUpdateValueFilter = ({ key, value }) => {
   updateState('valueFilter', {
     ...state.value.valueFilter,
-    [attribute]: valueFilter
+    [key]: value
   })
 }
 const onUpdateRendererName = rendererName => {
@@ -240,10 +249,10 @@ const onUpdateVals = vals => {
 const onDraggedAttribute = ({ key, value }) => {
   updateState(key, value)
 }
-const onUpdateOpenStatus = ({ attribute, status }) => {
+const onUpdateOpenStatus = ({ key, value }) => {
   updateState('openStatus', {
     ...state.value.openStatus,
-    [attribute]: status
+    [key]: value
   })
 }
 const pivotData = computed(() => new PivotData(state.value))


### PR DESCRIPTION
이슈 #23 

1. 필터박스 이벤트 파라미터 전달
@update:zIndexOfFilterBox="$emit('update:zIndexOfFilterBox', $event)"
@update:unselectedFilterValues="$emit('update:unselectedFilterValues', $event)"
@update:openStatusOfFilterBox="$emit('update:openStatusOfFilterBox', $event)"

2. VPIvottableUi 에 메소드 파라미터명 `key`, `value`로 수정 - `onUpdateValueFilter`, `onUpdateOpenStatus`

3. VPivottableUi 템플릿 내 <VDragAndDropCell>에 **props 추가** - `restrictedFromDragDrop`, `zIndices`, `openStatus`