### PR TITLE
Refactor/dragndrop

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -203,12 +203,6 @@ table.pvtTable tbody tr td {
   border: 1px solid #c8d4e3;
 }
 
-.pvtAxisContainer li span.pvtAttr.fixed {
-  border: 1px solid #c8d4e3;
-  color: #c5c5c5;
-  cursor: not-allowed;
-}
-
 .pvtTriangle {
   cursor: pointer;
   color: #506784;

--- a/src/components/pivottable-ui/VDragAndDropCell.vue
+++ b/src/components/pivottable-ui/VDragAndDropCell.vue
@@ -12,7 +12,6 @@
     <VDraggableAttribute
       v-for="item in modelItems"
       :key="item"
-      :fixed="fixedFromDragDrop.includes(item)"
       :restricted="restrictedFromDragDrop.includes(item)"
       :open="openStatus[item]"
       :unselectedFilterValues="valueFilter[item]"
@@ -69,10 +68,6 @@ const props = defineProps({
     default: () => ({})
   },
   restrictedFromDragDrop: {
-    type: Array,
-    default: () => []
-  },
-  fixedFromDragDrop: {
     type: Array,
     default: () => []
   },

--- a/src/components/pivottable-ui/VDragAndDropCell.vue
+++ b/src/components/pivottable-ui/VDragAndDropCell.vue
@@ -3,10 +3,11 @@
     tag="td"
     :list="modelItems"
     :group="{ name: 'sharted', pull: true, put: true }"
-    ghost-class=".pvtFilterBox"
-    :preventOnfFilter="false"
+    :ghost-class="'pvtPlaceholder'"
+    :preventOnFilter="false"
     :class="classes"
-    @sort="onDrag"
+    @change="onDragEnd"
+    :move="onDragMove"
   >
     <VDraggableAttribute
       v-for="item in modelItems"
@@ -51,7 +52,6 @@ const props = defineProps({
     type: String,
     required: true
   },
-  // 삭제할 수 있으면 삭제
   classes: {
     type: String,
     default: ''
@@ -68,7 +68,6 @@ const props = defineProps({
     type: Object,
     default: () => ({})
   },
-  // 같은 셀 내 이동만 가능(정렬)
   restrictedFromDragDrop: {
     type: Array,
     default: () => []
@@ -97,7 +96,18 @@ const props = defineProps({
 
 const modelItems = ref([])
 
-const onDrag = () => {
+const onDragMove = (event) => {
+  const draggedItem = event.draggedContext.element
+  const isCrossCellMove = event.from !== event.to
+
+  if (isCrossCellMove && props.restrictedFromDragDrop.includes(draggedItem)) {
+    return false
+  }
+
+  return true
+}
+
+const onDragEnd = () => {
   if (props.cellType !== 'unused') {
     emit('update:draggedAttribute', {
       key: props.cellType,

--- a/src/components/pivottable-ui/VDraggableAttribute.vue
+++ b/src/components/pivottable-ui/VDraggableAttribute.vue
@@ -1,5 +1,5 @@
 <template>
-  <li>
+  <li @mousedown="handleMouseDown">
     <span
       class="pvtAttr"
       :class="[filtered, { restricted }]"
@@ -11,7 +11,8 @@
       >
       <span
         v-if="!hideDropDown"
-        @click="toggleFilterBox"
+        @mousedown.stop
+        @click.stop="toggleFilterBox"
         class="pvtTriangle"
       >
         ▾
@@ -39,7 +40,8 @@ import { computed } from 'vue'
 const emit = defineEmits([
   'update:zIndexOfFilterBox',
   'update:unselectedFilterValues',
-  'update:openStatusOfFilterBox'
+  'update:openStatusOfFilterBox',
+  'mouse-down'
 ])
 
 const props = defineProps({
@@ -73,9 +75,18 @@ const props = defineProps({
 })
 
 const toggleFilterBox = () => {
+  console.log('toggle filter box')
   emit('update:openStatusOfFilterBox', {
     key: props.attributeName,
     value: !props.open
+  })
+}
+
+const handleMouseDown = () => {
+  console.log('handle mouse down')
+  emit('update:openStatusOfFilterBox', {
+    key: props.attributeName,
+    value: false
   })
 }
 

--- a/src/components/pivottable-ui/VDraggableAttribute.vue
+++ b/src/components/pivottable-ui/VDraggableAttribute.vue
@@ -95,7 +95,3 @@ const filtered = computed(() => {
     : null
 })
 </script>
-
-<style scoped>
-/* css sortonly를 sortOnly로 변경해야함 */
-</style>

--- a/src/components/pivottable-ui/VDraggableAttribute.vue
+++ b/src/components/pivottable-ui/VDraggableAttribute.vue
@@ -23,6 +23,7 @@
         :filterBoxKey="attributeName"
         :filterBoxValues="attributeValues"
         :zIndex="zIndex"
+        @mousedown.stop
         @update:zIndexOfFilterBox="$emit('update:zIndexOfFilterBox', $event)"
         @update:unselectedFilterValues="
           $emit('update:unselectedFilterValues', $event)
@@ -75,7 +76,6 @@ const props = defineProps({
 })
 
 const toggleFilterBox = () => {
-  console.log('toggle filter box')
   emit('update:openStatusOfFilterBox', {
     key: props.attributeName,
     value: !props.open
@@ -83,11 +83,12 @@ const toggleFilterBox = () => {
 }
 
 const handleMouseDown = () => {
-  console.log('handle mouse down')
-  emit('update:openStatusOfFilterBox', {
-    key: props.attributeName,
-    value: false
-  })
+  if (props.open) {
+    emit('update:openStatusOfFilterBox', {
+      key: props.attributeName,
+      value: false
+    })
+  }
 }
 
 const hideDropDown = computed(

--- a/src/components/pivottable-ui/VDraggableAttribute.vue
+++ b/src/components/pivottable-ui/VDraggableAttribute.vue
@@ -41,8 +41,7 @@ import { computed } from 'vue'
 const emit = defineEmits([
   'update:zIndexOfFilterBox',
   'update:unselectedFilterValues',
-  'update:openStatusOfFilterBox',
-  'mouse-down'
+  'update:openStatusOfFilterBox'
 ])
 
 const props = defineProps({

--- a/src/components/pivottable-ui/VDraggableAttribute.vue
+++ b/src/components/pivottable-ui/VDraggableAttribute.vue
@@ -2,7 +2,7 @@
   <li>
     <span
       class="pvtAttr"
-      :class="[filtered, { restricted, fixed }]"
+      :class="[filtered, { restricted }]"
     >
       <slot
         name="pvtAttr"
@@ -50,10 +50,6 @@ const props = defineProps({
   attributeValues: {
     type: Object,
     default: () => ({})
-  },
-  fixed: {
-    type: Boolean,
-    default: false
   },
   restricted: {
     type: Boolean,

--- a/src/components/pivottable-ui/VPivottableUi.vue
+++ b/src/components/pivottable-ui/VPivottableUi.vue
@@ -15,7 +15,6 @@
           :allFilters="allFilters"
           :valueFilter="state.valueFilter"
           :restrictedFromDragDrop="state.restrictedFromDragDrop"
-          :fixedFromDragDrop="state.fixedFromDragDrop"
           :hideFilterBoxOfUnusedAttributes="
             state.hideFilterBoxOfUnusedAttributes
           "
@@ -59,7 +58,6 @@
           :allFilters="allFilters"
           :valueFilter="state.valueFilter"
           :restrictedFromDragDrop="state.restrictedFromDragDrop"
-          :fixedFromDragDrop="state.fixedFromDragDrop"
           :hideFilterBoxOfUnusedAttributes="
             state.hideFilterBoxOfUnusedAttributes
           "
@@ -87,7 +85,6 @@
           :allFilters="allFilters"
           :valueFilter="state.valueFilter"
           :restrictedFromDragDrop="state.restrictedFromDragDrop"
-          :fixedFromDragDrop="state.fixedFromDragDrop"
           :hideFilterBoxOfUnusedAttributes="
             state.hideFilterBoxOfUnusedAttributes
           "
@@ -149,10 +146,6 @@ const props = defineProps({
     default: () => []
   },
   restrictedFromDragDrop: {
-    type: Array,
-    default: () => []
-  },
-  fixedFromDragDrop: {
     type: Array,
     default: () => []
   },


### PR DESCRIPTION
이슈 #33 #38 

(1) `restricted` 속성 다른 셀로 이동 못함
VDragAndDropCell 에 `onDragMove` 함수 추가
`onDragMove`에서 `restrcited` 속성을 다른 셀로 이동시키려는 경우 드래그 이벤트 중단 => `onDragEnd` 실행되지 않음

(2) `fixedFromDragDrop` prop 전역적으로 삭제
PivottableUi, VDragAndDropCell 에서 `fixedFromDragDrop` 삭제
VDraggableAttribute에서 `fixed` prop 삭제

(3) 필터박스 열린 상태로 드래그할 때 필터박스 닫기
=> 필터박스가 열린 상태에서 draggable item 영역 클릭시 필터박스를 닫는 방식으로 구현
VDraggableAttribute에 `@mousedown` 이벤트 추가 => 필터박스 열려있을 때 닫음(`@update:openStatusOfFilterBox`)
필터박스 여는 토글 버튼 & 필터박스 영역 클릭시에는 필터박스 닫히지않게 `@mousedown.stop` 추가