### PR TITLE
feat(composables): usePropsState TypeScript 마이그레이션

### DIFF
--- a/src/composables/usePropsState.ts
+++ b/src/composables/usePropsState.ts
@@ -1,0 +1,105 @@
+import { computed, reactive, ComputedRef, UnwrapRef } from 'vue'
+
+// 초기 props 타입 정의 (실제 프로젝트 상황에 맞게 확장 가능)
+export interface UsePropsStateProps {
+  languagePack: Record<string, { localeStrings: Record<string, string> }>
+  locale: string
+  valueFilter?: Record<string, any>
+  rendererName?: string
+  heatmapMode?: string
+  aggregatorName?: string
+  rowOrder?: string
+  colOrder?: string
+  vals?: any[]
+  [key: string]: any
+}
+
+export interface UsePropsStateReturn<T extends UsePropsStateProps> {
+  state: UnwrapRef<T>
+  localeStrings: ComputedRef<Record<string, string>>
+  updateState: (key: keyof T, value: any) => void
+  updateMultiple: (updates: Partial<T>) => void
+  onUpdateValueFilter: (payload: { key: string; value: any }) => void
+  onUpdateRendererName: (rendererName: string) => void
+  onUpdateAggregatorName: (aggregatorName: string) => void
+  onUpdateRowOrder: (rowOrder: string) => void
+  onUpdateColOrder: (colOrder: string) => void
+  onUpdateVals: (vals: any[]) => void
+  onDraggedAttribute: (payload: { key: keyof T; value: any }) => void
+}
+
+export function usePropsState<T extends UsePropsStateProps> (
+  initialProps: T
+): UsePropsStateReturn<T> {
+  const state = reactive({
+    ...initialProps
+  }) as UnwrapRef<T>
+
+  const localeStrings = computed<Record<string, string>>(
+    () => initialProps.languagePack[initialProps.locale].localeStrings
+  )
+
+  const updateState = (key: keyof T, value: any) => {
+    if (key in state) {
+      (state as any)[key] = value
+    }
+  }
+
+  const updateMultiple = (updates: Partial<T>) => {
+    Object.entries(updates).forEach(([key, value]) => {
+      if (key in state) {
+        (state as any)[key] = value
+      }
+    })
+  }
+
+  const onUpdateValueFilter = ({ key, value }: { key: string; value: any }) => {
+    updateState('valueFilter' as keyof T, {
+      ...(state.valueFilter || {}),
+      [key]: value
+    })
+  }
+
+  const onUpdateRendererName = (rendererName: string) => {
+    updateState('rendererName' as keyof T, rendererName)
+    if (rendererName === 'Table Heatmap') {
+      updateState('heatmapMode' as keyof T, 'full')
+    } else if (rendererName === 'Table Row Heatmap') {
+      updateState('heatmapMode' as keyof T, 'row')
+    } else if (rendererName === 'Table Col Heatmap') {
+      updateState('heatmapMode' as keyof T, 'col')
+    } else {
+      updateState('heatmapMode' as keyof T, '')
+    }
+  }
+
+  const onUpdateAggregatorName = (aggregatorName: string) => {
+    updateState('aggregatorName' as keyof T, aggregatorName)
+  }
+  const onUpdateRowOrder = (rowOrder: string) => {
+    updateState('rowOrder' as keyof T, rowOrder)
+  }
+  const onUpdateColOrder = (colOrder: string) => {
+    updateState('colOrder' as keyof T, colOrder)
+  }
+  const onUpdateVals = (vals: any[]) => {
+    updateState('vals' as keyof T, vals)
+  }
+  const onDraggedAttribute = ({ key, value }: { key: keyof T; value: any }) => {
+    updateState(key, value)
+  }
+
+  return {
+    state,
+    localeStrings,
+    updateState,
+    updateMultiple,
+    onUpdateValueFilter,
+    onUpdateRendererName,
+    onUpdateAggregatorName,
+    onUpdateRowOrder,
+    onUpdateColOrder,
+    onUpdateVals,
+    onDraggedAttribute
+  }
+} 


### PR DESCRIPTION
usePropsState.js → usePropsState.ts로 TypeScript 마이그레이션
- 기존 JS 파일 삭제
- helper import 경로 @ alias로 복구
- 빌드 경고/에러 0건까지 반복적으로 수정 및 테스트 완료
- 문서(reference/*)는 커밋 대상에서 제외

Closes #이슈번호(필요시)