### PR TITLE
fix: use official GitHub App token action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,23 +17,12 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - name: Debug secrets
-        run: |
-          echo "APP_ID length: ${#APP_ID}"
-          echo "PRIVATE_KEY length: ${#PRIVATE_KEY}"
-          echo "INSTALLATION_ID length: ${#INSTALLATION_ID}"
-        env:
-          APP_ID: ${{ secrets.APP_ID }}
-          PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-          INSTALLATION_ID: ${{ secrets.APP_INSTALLATION_ID }}
-
       - name: Generate GitHub App Token
         id: generate-token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
-          installation_id: ${{ secrets.APP_INSTALLATION_ID }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Switching from tibdex/github-app-token to actions/create-github-app-token for better compatibility