### PR TITLE
fix: 프로덕션 배포가 release 브랜치에서 실행되도록 수정

### DIFF
--- a/.changeset/fix-release-workflow.md
+++ b/.changeset/fix-release-workflow.md
@@ -1,0 +1,11 @@
+---
+"vue-pivottable": patch
+"@vue-pivottable/lazy-table-renderer": patch
+"@vue-pivottable/plotly-renderer": patch
+---
+
+fix: 프로덕션 배포가 release 브랜치에서 실행되도록 수정
+
+- release.yml에서 release-packages.cjs 사용하도록 변경
+- npm 배포 전 release 브랜치로 checkout하도록 수정
+- 베타와 프로덕션 배포가 동일한 스크립트 사용

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,11 +101,14 @@ jobs:
           echo "release_branch=$RELEASE_BRANCH" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Publish to npm
+      - name: Checkout release branch and publish
         if: steps.check-versions.outputs.has_beta == 'true'
         run: |
+          # Checkout to release branch for publishing
+          git checkout ${{ steps.create-release.outputs.release_branch }}
+          
           # Publish with latest tag (overwrites beta)
-          node scripts/release-packages.js
+          node scripts/release-packages.cjs
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## 📋 개요

프로덕션 배포 워크플로우가 release 브랜치에서 실행되도록 수정하고, 베타와 프로덕션이 동일한 배포 로직을 사용하도록 통일했습니다.

## 🔧 변경사항

- release.yml에서  사용하도록 변경
- npm 배포 전 release 브랜치로 checkout하도록 수정
- 베타와 프로덕션 배포가 동일한 스크립트 사용

## 🎯 해결된 문제

1. 베타 테스트는 성공하지만 프로덕션 배포는 실패하는 문제
2. 베타와 프로덕션이 다른 배포 로직을 사용하여 베타 테스트의 의미가 없던 문제
3. 프로덕션 배포가 main 브랜치에서 직접 실행되던 문제

## ✅ 테스트 계획

- [ ] develop 브랜치에서 베타 배포 테스트
- [ ] main 브랜치에서 프로덕션 배포 테스트
- [ ] release 브랜치가 정상적으로 생성되는지 확인
- [ ] npm 패키지가 올바른 버전으로 배포되는지 확인