### PR TITLE
fix: 하위 패키지 이중 베타 버전 제거

### DIFF
--- a/packages/lazy-table-renderer/package.json
+++ b/packages/lazy-table-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-pivottable/lazy-table-renderer",
-  "version": "1.1.0-beta.1750332684-beta.1750334434",
+  "version": "1.1.0",
   "type": "module",
   "description": "",
   "exports": {

--- a/packages/plotly-renderer/package.json
+++ b/packages/plotly-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-pivottable/plotly-renderer",
-  "version": "2.0.0-beta.1750332684-beta.1750334434",
+  "version": "2.0.0",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
워크플로우 버그로 인해 베타 버전이 두 번 붙은 문제 수정

- lazy-table-renderer: 1.1.0-beta.xxx-beta.xxx → 1.1.0
- plotly-renderer: 2.0.0-beta.xxx-beta.xxx → 2.0.0