### PR TITLE
fix: 하위 패키지 트리플 베타 버전 정상화

### DIFF
--- a/.changeset/fix-triple-beta.md
+++ b/.changeset/fix-triple-beta.md
@@ -1,0 +1,8 @@
+---
+"vue-pivottable": patch
+---
+
+fix: 하위 패키지 이중 베타 버전 문제 해결
+
+- lazy-table-renderer와 plotly-renderer의 잘못된 베타 버전 수정
+- 워크플로우 개선사항 적용을 위한 릴리스 준비

--- a/packages/lazy-table-renderer/package.json
+++ b/packages/lazy-table-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-pivottable/lazy-table-renderer",
-  "version": "1.1.0-beta.1750332684-beta.1750334434-beta.1750334835",
+  "version": "1.1.0",
   "type": "module",
   "description": "",
   "exports": {

--- a/packages/plotly-renderer/package.json
+++ b/packages/plotly-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-pivottable/plotly-renderer",
-  "version": "2.0.0-beta.1750332684-beta.1750334434-beta.1750334835",
+  "version": "2.0.0",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## 📋 개요

워크플로우 버그로 인해 하위 패키지에 베타 버전이 중복으로 붙은 문제를 해결합니다.

## 🔧 변경사항

- lazy-table-renderer: `1.1.0-beta.xxx-beta.xxx-beta.xxx` → `1.1.0`
- plotly-renderer: `2.0.0-beta.xxx-beta.xxx-beta.xxx` → `2.0.0`
- 프로덕션 릴리스를 위한 changeset 추가

## 🎯 예상 동작

1. **develop 머지 후**:
   - changeset 적용으로 vue-pivottable 1.1.3 → 1.1.4
   - 1.1.4-beta.xxx 버전 생성
   - develop → main PR 자동 생성

2. **main 머지 후**:
   - 1.1.4 stable 버전 배포
   - 하위 패키지는 이미 npm에 있으므로 스킵

## ✅ 체크리스트

- [x] 하위 패키지 버전 정상화
- [x] changeset 파일 추가
- [ ] develop 워크플로우 성공 확인
- [ ] develop → main PR 생성 확인