### PR TITLE
hotfix: main 워크플로우 버전 업데이트 오류 수정

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,8 +95,11 @@ jobs:
       - name: Update versions to stable
         if: steps.check-versions.outputs.has_beta == 'true'
         run: |
-          # Update main package
-          npm version ${{ steps.check-versions.outputs.base_version }} --no-git-tag-version
+          # Update main package only if it has beta
+          MAIN_VERSION=$(node -p "require('./package.json').version")
+          if [[ $MAIN_VERSION == *"-beta"* ]]; then
+            npm version ${{ steps.check-versions.outputs.base_version }} --no-git-tag-version
+          fi
           
           # Update sub-packages
           for pkg in packages/*/; do


### PR DESCRIPTION
## 🔥 긴급 수정

main 워크플로우가 실패하는 문제를 수정합니다.

## 🐛 문제
- 메인 패키지가 이미 stable(1.1.3)인데 같은 버전으로 업데이트 시도
- `npm version 1.1.3` → `Version not changed` 오류

## 🔧 해결
메인 패키지가 베타일 때만 버전 업데이트하도록 조건 추가

## 📊 현재 상황
- lazy-table-renderer: 1.1.1-beta.xxx (배포됨)
- main 워크플로우 실패로 stable 배포 안됨

이 수정 후 재실행하면 lazy-table-renderer가 stable 1.1.1로 배포됩니다.