### PR TITLE
feat: release 브랜치 워크플로우 분리

### DIFF
--- a/.changeset/test-sub-package-only.md
+++ b/.changeset/test-sub-package-only.md
@@ -1,0 +1,5 @@
+---
+"@vue-pivottable/lazy-table-renderer": patch
+---
+
+test: 하위 패키지만 업데이트하는 경우 릴리즈 브랜치 동기화 테스트

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -1,0 +1,160 @@
+name: Release Branch Deploy
+
+on:
+  push:
+    branches:
+      - 'release/v*'
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  deploy-and-sync:
+    name: Deploy and Sync
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.10.0'
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: latest
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build packages
+        run: |
+          echo "Building all packages..."
+          pnpm build:all
+
+      - name: Publish to npm
+        run: |
+          # Publish with latest tag
+          node scripts/release-packages.cjs
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN_SUMIN: ${{ secrets.NPM_TOKEN_SUMIN }}
+
+      - name: Create GitHub Releases
+        run: |
+          # Create release for each package with stable version
+          create_release() {
+            local PKG_NAME=$1
+            local PKG_VERSION=$2
+            local NPM_NAME=$3
+            
+            echo "Creating release for $PKG_NAME@$PKG_VERSION"
+            
+            # Delete existing beta release if it exists
+            gh release delete "${PKG_NAME}@${PKG_VERSION}" --yes 2>/dev/null || true
+            
+            gh release create "${PKG_NAME}@${PKG_VERSION}" \
+              --title "${PKG_NAME}@${PKG_VERSION}" \
+              --notes "## 🚀 Stable Release
+          
+          This release promotes the beta version to stable.
+          
+          Install with: \`npm install ${NPM_NAME}@latest\`
+          
+          ### Version: ${PKG_VERSION}" \
+              --target ${{ github.sha }}
+          }
+          
+          # Get version info from current branch
+          CURRENT_BRANCH="${{ github.ref_name }}"
+          VERSION="${CURRENT_BRANCH#release/v}"
+          
+          # Check main package
+          MAIN_VERSION=$(node -p "require('./package.json').version")
+          if [ "$MAIN_VERSION" = "$VERSION" ]; then
+            create_release "vue-pivottable" "$MAIN_VERSION" "vue-pivottable"
+          fi
+          
+          # Check sub-packages
+          for pkg in packages/*/; do
+            if [ -d "$pkg" ] && [ -f "$pkg/package.json" ]; then
+              FULL_PKG_NAME=$(cd "$pkg" && node -p "require('./package.json').name")
+              PKG_VERSION=$(cd "$pkg" && node -p "require('./package.json').version")
+              
+              # Only create release if version doesn't contain beta
+              if [[ $PKG_VERSION != *"-beta"* ]]; then
+                create_release "$FULL_PKG_NAME" "$PKG_VERSION" "$FULL_PKG_NAME"
+              fi
+            fi
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sync with develop
+        run: |
+          # Configure git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          # Create a temporary branch for merging
+          TEMP_BRANCH="temp-sync-$(date +%s)"
+          git checkout -b $TEMP_BRANCH
+          
+          # Merge into develop
+          git checkout develop
+          git pull origin develop
+          git merge $TEMP_BRANCH --no-edit -m "chore: sync release ${{ github.ref_name }} to develop"
+          git push origin develop
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create PR to main
+        run: |
+          VERSION="${{ github.ref_name }}"
+          
+          gh pr create \
+            --base main \
+            --head "${{ github.ref_name }}" \
+            --title "chore: update main with $VERSION" \
+            --body "## 📦 Release Update
+            
+            This PR updates main branch with:
+            - ✅ Stable version numbers (beta suffix removed)
+            - ✅ Updated package.json files
+            - ✅ npm packages published
+            - ✅ GitHub releases created
+            
+            ### Published Packages
+            $(node -p "
+              const main = require('./package.json');
+              let packages = \`- vue-pivottable@\${main.version}\`;
+              const fs = require('fs');
+              const path = require('path');
+              const packagesDir = './packages';
+              if (fs.existsSync(packagesDir)) {
+                fs.readdirSync(packagesDir).forEach(dir => {
+                  const pkgPath = path.join(packagesDir, dir, 'package.json');
+                  if (fs.existsSync(pkgPath)) {
+                    const pkg = require(pkgPath);
+                    packages += \`\\n- \${pkg.name}@\${pkg.version}\`;
+                  }
+                });
+              }
+              packages
+            ")
+            
+            **Note**: This release has been automatically synced with develop branch." \
+            || echo "PR to main already exists or creation failed"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,97 +134,12 @@ jobs:
           echo "release_branch=$RELEASE_BRANCH" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Checkout release branch and publish
+      - name: Trigger release branch workflow
         if: steps.check-versions.outputs.has_beta == 'true'
         run: |
-          # Checkout to release branch for publishing
-          git checkout ${{ steps.create-release.outputs.release_branch }}
-          
-          # Publish with latest tag (overwrites beta)
-          node scripts/release-packages.cjs
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOKEN_SUMIN: ${{ secrets.NPM_TOKEN_SUMIN }}
-
-      - name: Create GitHub Releases
-        if: steps.check-versions.outputs.has_beta == 'true'
-        run: |
-          # Create release for each package with stable version
-          create_release() {
-            local PKG_NAME=$1
-            local PKG_VERSION=$2
-            local NPM_NAME=$3
-            
-            echo "Creating release for $PKG_NAME@$PKG_VERSION"
-            
-            # Delete existing release if it exists (likely a beta version)
-            gh release delete "${PKG_NAME}@${PKG_VERSION}" --yes 2>/dev/null || true
-            
-            gh release create "${PKG_NAME}@${PKG_VERSION}" \
-              --title "${PKG_NAME}@${PKG_VERSION}" \
-              --notes "## 🚀 Stable Release
-          
-          This release promotes the beta version to stable.
-          
-          Install with: \`npm install ${NPM_NAME}@latest\`
-          
-          ### Version: ${PKG_VERSION}" \
-              --target ${{ github.sha }}
-          }
-          
-          # Only create releases for packages that had beta versions
-          BETA_PACKAGES="${{ steps.check-versions.outputs.beta_packages }}"
-          
-          # Check if main package had beta
-          if [[ " $BETA_PACKAGES " == *" vue-pivottable "* ]]; then
-            MAIN_VERSION=$(node -p "require('./package.json').version")
-            create_release "vue-pivottable" "$MAIN_VERSION" "vue-pivottable"
-          fi
-          
-          # Check sub-packages
-          for pkg in packages/*/; do
-            if [ -d "$pkg" ] && [ -f "$pkg/package.json" ]; then
-              PKG_NAME=$(basename "$pkg")
-              # Only process if this package had beta version
-              if [[ " $BETA_PACKAGES " == *" $PKG_NAME "* ]]; then
-                FULL_PKG_NAME=$(cd "$pkg" && node -p "require('./package.json').name")
-                PKG_VERSION=$(cd "$pkg" && node -p "require('./package.json').version")
-                create_release "$FULL_PKG_NAME" "$PKG_VERSION" "$FULL_PKG_NAME"
-              fi
-            fi
-          done
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create PR to update main
-        if: steps.check-versions.outputs.has_beta == 'true'
-        run: |
-          # Create PR from release branch back to main
-          gh pr create \
-            --base main \
-            --head ${{ steps.create-release.outputs.release_branch }} \
-            --title "chore: update main with release v${{ steps.create-release.outputs.version }}" \
-            --body "## 📦 Release Update
-            
-            This PR updates main branch with:
-            - ✅ Stable version numbers (beta suffix removed)
-            - ✅ Updated package.json files
-            - ✅ Release commit
-            
-            **Note**: Changesets were already consumed in develop branch." \
-            || echo "PR creation failed"
-          
-          # Also create PR to sync with develop
-          gh pr create \
-            --base develop \
-            --head ${{ steps.create-release.outputs.release_branch }} \
-            --title "chore: sync release v${{ steps.create-release.outputs.version }} to develop" \
-            --body "## 🔄 Release Sync
-            
-            This PR syncs the stable release back to develop:
-            - ✅ Version alignment
-            - ✅ Ensures develop has latest stable version
-            
-            **Important**: Review carefully for any conflicts with ongoing development." \
-            || echo "Sync PR creation failed"
+          echo "Release branch created: ${{ steps.create-release.outputs.release_branch }}"
+          echo "The release branch workflow will handle:"
+          echo "- Publishing to npm"
+          echo "- Creating GitHub releases"
+          echo "- Syncing with develop (auto-merge)"
+          echo "- Creating PR to main"


### PR DESCRIPTION
## 🚀 새로운 기능

### Release 브랜치 워크플로우 분리
- : release 브랜치에서 실행되는 워크플로우 추가
- : release 브랜치 생성만 담당하도록 수정

### 워크플로우 흐름
1. **main 브랜치 (release.yml)**
   - 베타 버전 확인
   - release/vX.X.X 브랜치 생성
   - 베타 버전 제거

2. **release 브랜치 (release-branch.yml)**
   - npm 배포
   - GitHub Release 태그 생성
   - develop 브랜치로 자동 머지
   - main 브랜치로 PR 생성

### 테스트
- lazy-table-renderer만 업데이트하는 changeset 포함
- 하위 패키지만 변경될 때도 정상적으로 동기화되는지 확인

### 개선사항
- 하위 패키지만 업데이트되는 경우에도 동기화 작업이 정상적으로 수행됨
- release 브랜치에서 모든 배포 관련 작업이 처리됨