### PR TITLE
fix: 베타 버전이 있는 패키지만 빌드/배포하도록 개선

### DIFF
--- a/.changeset/test-release-workflow.md
+++ b/.changeset/test-release-workflow.md
@@ -1,0 +1,5 @@
+---
+"@vue-pivottable/lazy-table-renderer": patch
+---
+
+test: 릴리스 워크플로우 개선 테스트

--- a/packages/lazy-table-renderer/package.json
+++ b/packages/lazy-table-renderer/package.json
@@ -43,7 +43,7 @@
   "license": "MIT",
   "scripts": {
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s --scope lazy-table-renderer",
-    "clean": "rimraf lib",
+    "clean": "rimraf dist",
     "build": "vite build",
     "lint": "eslint ."
   },

--- a/packages/plotly-renderer/package.json
+++ b/packages/plotly-renderer/package.json
@@ -37,6 +37,7 @@
   "author": "Sumin, Lee <lsumin1127@gmail.com>",
   "license": "MIT",
   "scripts": {
+    "clean": "rimraf dist",
     "build": "vite build"
   },
   "dependencies": {

--- a/scripts/release-packages.cjs
+++ b/scripts/release-packages.cjs
@@ -25,20 +25,20 @@ const packages = [
   {
     name: 'vue3-pivottable',
     path: '.',
-    buildCmd: 'pnpm build',
+    buildCmd: 'pnpm clean && pnpm build',
     publishCmd: 'pnpm changeset publish'
   },
   {
     name: '@vue-pivottable/plotly-renderer',
     path: './packages/plotly-renderer',
-    buildCmd: 'pnpm --filter @vue-pivottable/plotly-renderer build',
+    buildCmd: 'pnpm --filter @vue-pivottable/plotly-renderer clean && pnpm --filter @vue-pivottable/plotly-renderer build',
     publishCmd: 'pnpm changeset publish --filter @vue-pivottable/plotly-renderer',
     tokenEnv: 'NPM_TOKEN_SUMIN'
   },
   {
     name: '@vue-pivottable/lazy-table-renderer',
     path: './packages/lazy-table-renderer',
-    buildCmd: 'pnpm --filter @vue-pivottable/lazy-table-renderer build',
+    buildCmd: 'pnpm --filter @vue-pivottable/lazy-table-renderer clean && pnpm --filter @vue-pivottable/lazy-table-renderer build',
     publishCmd: 'pnpm changeset publish --filter @vue-pivottable/lazy-table-renderer',
     tokenEnv: 'NPM_TOKEN_SUMIN'
   }
@@ -60,6 +60,17 @@ async function releasePackages() {
       // Check if package directory exists
       if (!fs.existsSync(pkg.path)) {
         throw new Error(`Package directory not found: ${pkg.path}`);
+      }
+
+      // Get package version
+      const packageJsonPath = `${pkg.path}/package.json`;
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+      const currentVersion = packageJson.version;
+
+      // Skip if not a beta version (no changeset)
+      if (!currentVersion.includes('-beta')) {
+        log.info(`Skipping ${pkg.name} - no beta version (${currentVersion})`);
+        continue;
       }
 
       // Build package


### PR DESCRIPTION
## 개요
베타 버전이 없는(changeset이 없는) 패키지는 빌드/배포를 시도하지 않도록 개선

## 변경사항
### 1. release-packages.cjs 개선
- 베타 버전 체크 로직 추가
- 베타 버전이 없는 패키지는 스킵 (불필요한 빌드 방지)

### 2. 패키지별 clean 스크립트 추가/수정
- plotly-renderer: clean 스크립트 추가 (`rimraf dist`)
- lazy-table-renderer: clean 대상 수정 (lib → dist)

### 3. 빌드 명령어에 clean 포함
- 모든 패키지의 빌드 전에 clean 실행
- 이전 빌드 잔재로 인한 문제 방지

## 해결되는 문제
1. changeset이 없는 패키지의 불필요한 빌드 시도 제거
2. 이전 dist가 남아있어서 빌드 실패해도 배포되는 문제 해결
3. 빌드 실패 시 changeset이 정상적으로 유지되도록 보장