### PR TITLE
fix: 중복된 베타 버전 suffix 제거 로직 개선

### DIFF
--- a/.changeset/fix-plotly-beta-version.md
+++ b/.changeset/fix-plotly-beta-version.md
@@ -1,0 +1,5 @@
+---
+"@vue-pivottable/plotly-renderer": patch
+---
+
+fix: 중복된 베타 버전 정리

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,8 @@ jobs:
               cd "$pkg"
               PKG_VERSION=$(node -p "require('./package.json').version")
               if [[ $PKG_VERSION == *"-beta"* ]]; then
-                PKG_BASE=$(echo $PKG_VERSION | sed 's/-beta.*//')
+                # Remove all beta suffixes (handle multiple -beta occurrences)
+                PKG_BASE=$(echo $PKG_VERSION | sed 's/-beta.*$//')
                 npm version $PKG_BASE --no-git-tag-version
               fi
               cd -


### PR DESCRIPTION
## 개요
베타 버전 제거 시 중복된 베타 suffix를 모두 제거하도록 개선

## 문제 상황
plotly-renderer가 잘못된 작업으로 인해 베타가 4번 붙은 상태:
`2.0.1-beta.111-beta.222-beta.333-beta.444`

## 해결책
release.yml의 sed 명령어 수정:
- 기존: `sed 's/-beta.*//'`
- 수정: `sed 's/-beta.*$//'`

첫 번째 `-beta`부터 문자열 끝까지 모두 제거하여 깨끗한 버전 번호만 남김

## 결과
`2.0.1-beta.111-beta.222-beta.333-beta.444` → `2.0.1`