### PR TITLE
fix: plotly-renderer 베타 버전 latest 태그 문제 수정

### DIFF
--- a/.changeset/fix-plotly-beta-latest.md
+++ b/.changeset/fix-plotly-beta-latest.md
@@ -1,0 +1,5 @@
+---
+"@vue-pivottable/plotly-renderer": patch
+---
+
+fix: 잘못된 베타 버전이 latest 태그로 배포된 문제 수정


### PR DESCRIPTION
## 개요
npm에 잘못된 베타 버전이 latest 태그로 배포된 문제를 수정하기 위한 changeset 추가

## 문제 상황
- 현재 npm latest: `@vue-pivottable/plotly-renderer@2.0.2-beta.1750376710-beta.1750377441`
- 베타 버전이 production latest 태그로 배포됨

## 해결책
- changeset을 추가하여 새로운 patch 버전 릴리스
- 정상적인 버전 번호로 latest 태그 업데이트

## 예상 결과
- develop 머지 → `2.0.3-beta.xxx` 생성
- main 머지 → `2.0.3` 정식 버전으로 latest 태그 업데이트