### PR TITLE
fix: npm 배포 시 태그를 환경 변수로 제어하도록 개선

### DIFF
--- a/.changeset/test-beta-tag-fix.md
+++ b/.changeset/test-beta-tag-fix.md
@@ -1,0 +1,5 @@
+---
+"@vue-pivottable/plotly-renderer": patch
+---
+
+test: 베타 태그 배포 수정 테스트

--- a/scripts/release-packages.cjs
+++ b/scripts/release-packages.cjs
@@ -20,26 +20,30 @@ const log = {
   warning: (msg) => console.log(`${colors.yellow}⚠${colors.reset} ${msg}`)
 };
 
+// Get release tag from environment variable
+const releaseTag = process.env.RELEASE_TAG || 'latest';
+log.info(`Publishing with tag: ${releaseTag}`);
+
 // Package configurations
 const packages = [
   {
     name: 'vue3-pivottable',
     path: '.',
     buildCmd: 'pnpm clean && pnpm build',
-    publishCmd: 'pnpm changeset publish'
+    publishCmd: `pnpm changeset publish --tag ${releaseTag}`
   },
   {
     name: '@vue-pivottable/plotly-renderer',
     path: './packages/plotly-renderer',
     buildCmd: 'pnpm --filter @vue-pivottable/plotly-renderer clean && pnpm --filter @vue-pivottable/plotly-renderer build',
-    publishCmd: 'pnpm changeset publish --filter @vue-pivottable/plotly-renderer',
+    publishCmd: `pnpm changeset publish --filter @vue-pivottable/plotly-renderer --tag ${releaseTag}`,
     tokenEnv: 'NPM_TOKEN_SUMIN'
   },
   {
     name: '@vue-pivottable/lazy-table-renderer',
     path: './packages/lazy-table-renderer',
     buildCmd: 'pnpm --filter @vue-pivottable/lazy-table-renderer clean && pnpm --filter @vue-pivottable/lazy-table-renderer build',
-    publishCmd: 'pnpm changeset publish --filter @vue-pivottable/lazy-table-renderer',
+    publishCmd: `pnpm changeset publish --filter @vue-pivottable/lazy-table-renderer --tag ${releaseTag}`,
     tokenEnv: 'NPM_TOKEN_SUMIN'
   }
 ];


### PR DESCRIPTION
## 개요
베타 버전이 latest 태그로 배포되는 문제를 해결하기 위해 npm 태그를 환경 변수로 제어하도록 개선

## 문제 상황
- develop 브랜치에서 베타 버전을 배포했는데 latest 태그로 배포됨
- 결과적으로 `npm install @vue-pivottable/plotly-renderer` 시 베타 버전이 설치됨

## 해결책
- `RELEASE_TAG` 환경 변수로 npm 배포 태그 지정
- develop 브랜치: `RELEASE_TAG=beta`로 베타 태그 배포
- main/release 브랜치: 기본값 `latest` 태그로 배포

## 동작 방식
### develop 브랜치 (release-develop.yml)
```bash
RELEASE_TAG=beta node scripts/release-packages.cjs
# → npm publish --tag beta
```

### main/release 브랜치 (release.yml)
```bash
node scripts/release-packages.cjs
# → npm publish --tag latest (기본값)
```

## 결과
- develop: 베타 버전은 베타 태그로만 배포
- main: 정식 버전은 latest 태그로 배포
- 사용자는 `npm install`로 안정된 버전만 받음