### PR TITLE
fix: npm 배포 태그 및 베타 체크 로직 개선

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,7 +246,7 @@ jobs:
                 fs.readdirSync(packagesDir).forEach(dir => {
                   const pkgPath = path.join(packagesDir, dir, 'package.json');
                   if (fs.existsSync(pkgPath)) {
-                    const pkg = require(pkgPath);
+                    const pkg = require(path.resolve(pkgPath));
                     packages += \`\\n- \${pkg.name}@\${pkg.version}\`;
                   }
                 });

--- a/scripts/release-packages.cjs
+++ b/scripts/release-packages.cjs
@@ -71,8 +71,8 @@ async function releasePackages() {
       const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
       const currentVersion = packageJson.version;
 
-      // Skip if not a beta version (no changeset)
-      if (!currentVersion.includes('-beta')) {
+      // Skip non-beta versions only when publishing with beta tag
+      if (releaseTag === 'beta' && !currentVersion.includes('-beta')) {
         log.info(`Skipping ${pkg.name} - no beta version (${currentVersion})`);
         continue;
       }


### PR DESCRIPTION
## 개요
베타 버전이 latest 태그로 배포되는 문제와 정식 버전이 배포되지 않는 문제 해결

## 문제 상황
1. develop에서 베타 버전이 latest 태그로 배포됨
2. main에서 정식 버전이 배포되지 않음 (베타 체크로 인한 스킵)

## 해결책
1. **npm 태그를 환경 변수로 제어**
   - develop: `RELEASE_TAG=beta`
   - main: `RELEASE_TAG=latest` (기본값)

2. **베타 체크 로직 개선**
   - develop (beta 태그): 베타 버전만 배포
   - main (latest 태그): 모든 버전 배포

3. **PR 생성 시 require 경로 오류 수정**

## 변경사항
- release-packages.cjs: 환경 변수로 npm 태그 제어
- release-packages.cjs: 베타 체크는 beta 태그 배포 시에만
- release.yml: PR body의 require 경로 수정

## 테스트
- plotly-renderer changeset 포함