### PR TITLE
fix: develop 브랜치의 베타 버전 문제 긴급 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-pivottable",
-  "version": "1.1.5-beta.1750384228-beta.1750384534",
+  "version": "1.1.5-beta.1750384534",
   "type": "module",
   "description": "",
   "exports": {

--- a/packages/plotly-renderer/package.json
+++ b/packages/plotly-renderer/package.json
@@ -46,7 +46,7 @@
   },
   "peerDependencies": {
     "vue": "^3.2.0",
-    "vue-pivottable": "^1.1.5-beta.1750384228"
+    "vue-pivottable": "^1.1.4"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.1",


### PR DESCRIPTION
## 🚨 긴급 수정

develop 브랜치에 잘못 커밋된 베타 버전 문제를 수정합니다.

### 문제점
1. **베타 버전 중복**: `1.1.5-beta.1750384228-beta.1750384534`
2. **peerDependencies 오염**: plotly-renderer의 peerDependencies에 베타 버전이 들어감

### 해결
1. 중복된 베타 버전 제거
2. peerDependencies를 원래 버전(^1.1.4)으로 복원

### 영향
- 이 수정 후 PR #240이 정상적으로 병합 가능
- CI 체크 통과 가능

이 PR을 먼저 머지한 후 PR #240을 진행해야 합니다.