### PR TITLE
fix: 베타 릴리즈 프로세스 종합 개선

### DIFF
--- a/.changeset/fix-beta-release-complete.md
+++ b/.changeset/fix-beta-release-complete.md
@@ -1,0 +1,11 @@
+---
+"vue-pivottable": patch
+"@vue-pivottable/plotly-renderer": patch
+---
+
+fix: 베타 릴리즈 프로세스 전체 개선
+
+- 베타 버전 중복 문제 해결 (1.1.5-beta.xxx-beta.yyy → 1.1.5-beta.yyy)
+- peerDependencies 베타 버전 오염 방지
+- changeset 적용 전 package.json 백업 및 peerDependencies 복원 로직 추가
+- 워크플로우에서 베타 버전이 의존성에 전파되지 않도록 개선

--- a/.changeset/fix-develop-beta-issues.md
+++ b/.changeset/fix-develop-beta-issues.md
@@ -1,0 +1,9 @@
+---
+"vue-pivottable": patch
+"@vue-pivottable/plotly-renderer": patch
+---
+
+fix: 베타 버전 중복 및 peerDependencies 오염 문제 긴급 수정
+
+- 중복된 베타 버전 제거 (1.1.5-beta.xxx-beta.yyy → 1.1.5-beta.yyy)
+- plotly-renderer의 peerDependencies를 원래 버전으로 복원

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -91,6 +91,13 @@ jobs:
             fi
           done
           
+          # Store package.json files before changeset modifications
+          for pkg in packages/*/; do
+            if [ -d "$pkg" ] && [ -f "$pkg/package.json" ]; then
+              cp "$pkg/package.json" "$pkg/package.json.backup"
+            fi
+          done
+          
           # Commit all changes
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -98,6 +105,32 @@ jobs:
           git commit -m "chore: prepare beta release
           
           Changed packages: $CHANGED_PACKAGES"
+          
+          # Restore peerDependencies from backup to prevent beta version pollution
+          for pkg in packages/*/; do
+            if [ -d "$pkg" ] && [ -f "$pkg/package.json.backup" ]; then
+              cd "$pkg"
+              # Extract peerDependencies from backup and apply to current
+              node -e "
+                const fs = require('fs');
+                const backup = JSON.parse(fs.readFileSync('./package.json.backup', 'utf8'));
+                const current = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+                if (backup.peerDependencies) {
+                  current.peerDependencies = backup.peerDependencies;
+                }
+                fs.writeFileSync('./package.json', JSON.stringify(current, null, 2) + '\\n');
+              "
+              rm -f package.json.backup
+              cd -
+            fi
+          done
+          
+          # Commit peerDependencies fix if there are changes
+          if ! git diff --quiet; then
+            git add -A
+            git commit -m "fix: restore peerDependencies to prevent beta version pollution"
+          fi
+          
           git push origin develop
           
           # Always use current main package version for GitHub release tag

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-pivottable",
-  "version": "1.1.5-beta.1750384228-beta.1750384534",
+  "version": "1.1.5-beta.1750384534",
   "type": "module",
   "description": "",
   "exports": {

--- a/packages/plotly-renderer/package.json
+++ b/packages/plotly-renderer/package.json
@@ -46,7 +46,7 @@
   },
   "peerDependencies": {
     "vue": "^3.2.0",
-    "vue-pivottable": "^1.1.5-beta.1750384228"
+    "vue-pivottable": "^1.1.4"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.1",


### PR DESCRIPTION
## 🔧 종합 수정

develop 브랜치의 현재 문제와 향후 발생 방지를 위한 워크플로우 개선을 한 번에 해결합니다.

### 수정된 문제들

#### 1. 현재 develop 브랜치 문제 해결
- ✅ 베타 버전 중복 제거: `1.1.5-beta.xxx-beta.yyy` → `1.1.5-beta.yyy`
- ✅ plotly-renderer의 peerDependencies 복원: `^1.1.5-beta.xxx` → `^1.1.4`

#### 2. 워크플로우 개선
- ✅ changeset 적용 시 package.json 백업
- ✅ 베타 버전 생성 후 peerDependencies만 원래 버전으로 복원
- ✅ 별도 커밋으로 peerDependencies 수정사항 기록

### 작동 방식

```bash
# 1. changeset version 실행 전 package.json 백업
cp package.json package.json.backup

# 2. changeset version 실행 (버전과 의존성 모두 업데이트됨)
pnpm changeset version

# 3. 베타 버전 추가
npm version ${VERSION}-beta.${TIMESTAMP}

# 4. 첫 번째 커밋 (베타 버전 포함)
git commit -m "chore: prepare beta release"

# 5. peerDependencies만 백업에서 복원
# (version은 베타 유지, peerDependencies는 원래 버전)

# 6. 두 번째 커밋 (peerDependencies 수정)
git commit -m "fix: restore peerDependencies to prevent beta version pollution"
```

### 장점
- 베타 버전이 다른 패키지의 의존성에 전파되지 않음
- 깔끔한 히스토리 (두 개의 명확한 커밋)
- 향후 동일한 문제 발생 방지

### 테스트
- [x] changeset 추가로 CI 체크 통과
- [x] lockfile 업데이트 완료