### PR TITLE
fix: develop 브랜치를 베타 버전으로 긴급 복구

### DIFF
--- a/.changeset/restore-beta-versions.md
+++ b/.changeset/restore-beta-versions.md
@@ -1,0 +1,11 @@
+---
+"vue-pivottable": patch
+"@vue-pivottable/plotly-renderer": patch  
+"@vue-pivottable/lazy-table-renderer": patch
+---
+
+fix: develop 브랜치를 베타 버전으로 복구
+
+- develop 브랜치가 정식 버전으로 잘못 업데이트된 것을 수정
+- 모든 패키지를 베타 버전으로 변경
+- develop 브랜치는 항상 베타 버전을 유지해야 함

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-pivottable",
-  "version": "1.1.5",
+  "version": "1.1.5-beta.1750391874",
   "type": "module",
   "description": "",
   "exports": {

--- a/packages/lazy-table-renderer/package.json
+++ b/packages/lazy-table-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-pivottable/lazy-table-renderer",
-  "version": "1.1.6",
+  "version": "1.1.6-beta.1750391874",
   "type": "module",
   "description": "",
   "exports": {

--- a/packages/plotly-renderer/package.json
+++ b/packages/plotly-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-pivottable/plotly-renderer",
-  "version": "2.0.6",
+  "version": "2.0.6-beta.1750391874",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## 🚨 긴급 수정

develop 브랜치가 정식 버전으로 잘못 업데이트된 것을 베타 버전으로 복구합니다.

### 문제
PR #242 병합 과정에서 워크플로우가 제대로 작동하지 않아 develop 브랜치가 정식 버전이 되었습니다:
- vue-pivottable: 1.1.5 (정식)
- plotly-renderer: 2.0.6 (정식)
- lazy-table-renderer: 1.1.6 (정식)

### 해결
모든 패키지를 베타 버전으로 변경:
- vue-pivottable: 1.1.5-beta.1750391874
- plotly-renderer: 2.0.6-beta.1750391874
- lazy-table-renderer: 1.1.6-beta.1750391874

### 중요
**develop 브랜치는 항상 베타 버전을 유지해야 합니다.**

이 PR을 머지한 후에는 워크플로우가 정상적으로 작동하는지 확인이 필요합니다.