### PR TITLE
fix: peerDependencies 버전 수정으로 PR #238 CI 실패 해결

### DIFF
--- a/.changeset/fix-peer-dependencies.md
+++ b/.changeset/fix-peer-dependencies.md
@@ -1,0 +1,8 @@
+---
+"@vue-pivottable/plotly-renderer": patch
+---
+
+fix: peerDependencies가 존재하지 않는 버전을 참조하는 문제 수정
+
+- vue-pivottable의 peerDependency를 ^1.1.5에서 ^1.1.4로 변경
+- 1.1.5는 아직 정식 릴리즈되지 않았으므로 1.1.4를 참조해야 함

--- a/packages/plotly-renderer/package.json
+++ b/packages/plotly-renderer/package.json
@@ -46,7 +46,7 @@
   },
   "peerDependencies": {
     "vue": "^3.2.0",
-    "vue-pivottable": "^1.1.5"
+    "vue-pivottable": "^1.1.4"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.1",


### PR DESCRIPTION
## 🐛 버그 수정

PR #238의 CI 체크 실패를 해결합니다.

### 문제
PR #238 (develop → main)의 모든 체크가 실패:
```
ERR_PNPM_OUTDATED_LOCKFILE Cannot install with "frozen-lockfile"
specifiers in the lockfile ({..."vue-pivottable":"^1.1.4"...}) 
don't match specs in package.json ({..."vue-pivottable":"^1.1.5"...})
```

### 원인
- plotly-renderer의 peerDependencies가 `^1.1.5`를 요구
- 하지만 1.1.5는 아직 정식 릴리즈되지 않음 (베타 버전만 존재)
- lockfile은 1.1.4를 참조하고 있어 불일치 발생

### 해결
- plotly-renderer의 peerDependency를 `^1.1.4`로 수정
- 실제 존재하는 최신 정식 버전을 참조하도록 변경

### 영향
- PR #238의 CI 체크가 통과할 수 있게 됨
- develop → main 릴리즈 프로세스가 정상적으로 진행 가능