### PR TITLE
fix: PR #238 CI 실패 해결

### DIFF
--- a/.changeset/fix-pr238-ci.md
+++ b/.changeset/fix-pr238-ci.md
@@ -1,9 +1,10 @@
 ---
 "@vue-pivottable/plotly-renderer": patch
+"@vue-pivottable/lazy-table-renderer": patch
 ---
 
-fix: PR #238 CI 실패 문제 해결
+fix: peerDependencies가 존재하지 않는 버전을 참조하는 문제 수정
 
-- plotly-renderer의 peerDependencies에서 vue-pivottable 버전을 ^1.1.5에서 ^1.1.4로 수정
-- 아직 정식 릴리즈되지 않은 1.1.5를 참조하여 lockfile 불일치 오류 발생
-- 현재 최신 정식 버전인 1.1.4를 참조하도록 수정
+- vue-pivottable의 peerDependency를 ^1.1.5에서 ^1.1.4로 변경
+- 1.1.5는 아직 정식 릴리즈되지 않았으므로 1.1.4를 참조해야 함
+- plotly-renderer와 lazy-table-renderer 모두 수정

--- a/.changeset/fix-pr238-ci.md
+++ b/.changeset/fix-pr238-ci.md
@@ -1,0 +1,9 @@
+---
+"@vue-pivottable/plotly-renderer": patch
+---
+
+fix: PR #238 CI 실패 문제 해결
+
+- plotly-renderer의 peerDependencies에서 vue-pivottable 버전을 ^1.1.5에서 ^1.1.4로 수정
+- 아직 정식 릴리즈되지 않은 1.1.5를 참조하여 lockfile 불일치 오류 발생
+- 현재 최신 정식 버전인 1.1.4를 참조하도록 수정

--- a/packages/lazy-table-renderer/package.json
+++ b/packages/lazy-table-renderer/package.json
@@ -49,7 +49,7 @@
   },
   "peerDependencies": {
     "vue": "^3.2.0",
-    "vue-pivottable": "^1.1.5"
+    "vue-pivottable": "^1.1.4"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.1",

--- a/packages/plotly-renderer/package.json
+++ b/packages/plotly-renderer/package.json
@@ -46,7 +46,7 @@
   },
   "peerDependencies": {
     "vue": "^3.2.0",
-    "vue-pivottable": "^1.1.5"
+    "vue-pivottable": "^1.1.4"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.1",


### PR DESCRIPTION
## 🐛 문제 해결

PR #238 (develop → main)의 CI 체크 실패를 해결합니다.

### 문제 상황
PR #238의 모든 CI 체크가 다음 오류로 실패:
```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile"
specifiers in the lockfile ({"vue-pivottable":"^1.1.4"}) 
don't match specs in package.json ({"vue-pivottable":"^1.1.5"})
```

### 원인 분석
1. plotly-renderer의 peerDependencies가 `vue-pivottable: ^1.1.5`를 요구
2. 하지만 버전 1.1.5는 아직 정식 릴리즈되지 않음 (베타 버전만 존재)
3. pnpm lockfile은 최신 정식 버전인 1.1.4를 참조
4. CI 환경의 `--frozen-lockfile` 옵션으로 인해 불일치 감지 시 실패

### 해결 방법
- plotly-renderer의 peerDependencies를 `^1.1.4`로 수정
- 실제 존재하는 최신 정식 버전을 참조하도록 변경

### 확인 사항
- [x] changeset 파일 추가
- [x] lockfile 업데이트 (변경 없음 확인)
- [x] 최신 develop 브랜치에서 작업하여 충돌 방지

이 PR이 머지되면 PR #238의 CI가 정상적으로 통과할 것입니다.