### PR TITLE
test: 베타 타임스탬프 교체 시나리오 테스트

### DIFF
--- a/.changeset/test-beta-timestamp-replacement.md
+++ b/.changeset/test-beta-timestamp-replacement.md
@@ -1,0 +1,21 @@
+---
+"vue-pivottable": patch
+"@vue-pivottable/plotly-renderer": patch
+---
+
+test: 베타 타임스탬프 교체 시나리오 테스트
+
+**현재 상황:**
+- develop 브랜치에 이미 베타 버전들이 존재
+- main PR #247이 승인되지 않은 상태
+- 추가 changeset으로 베타 타임스탬프 교체 테스트
+
+**기대 결과:**
+- vue-pivottable: 1.1.6-beta.OLD → 1.1.7-beta.NEW
+- plotly-renderer: 2.0.7-beta.OLD → 2.0.8-beta.NEW
+- lazy-table-renderer: 1.1.7-beta.OLD (변경 없음, changeset 없음)
+
+**테스트 목표:**
+- 베타 중복 방지 (1.1.7-beta.xxx-beta.yyy 같은 형태 방지)
+- 새로운 타임스탬프로 교체
+- main PR #247 자동 업데이트

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -75,14 +75,16 @@ jobs:
           TIMESTAMP=$(date +%s)
           CHANGED_PACKAGES=""
           
-          # Function to ensure beta version
+          # Function to ensure beta version with timestamp replacement
           ensure_beta_version() {
             local current_version=$1
             local timestamp=$2
             
-            # If already has beta suffix, keep it
+            # If already has beta suffix, replace the timestamp
             if [[ "$current_version" == *"-beta."* ]]; then
-              echo "$current_version"
+              # Extract base version before first -beta
+              local base_version=$(echo "$current_version" | sed 's/-beta\..*//')
+              echo "${base_version}-beta.${timestamp}"
             else
               # Add beta suffix
               echo "${current_version}-beta.${timestamp}"


### PR DESCRIPTION
## 🧪 베타 타임스탬프 교체 시나리오 테스트

### 현재 상황
- **develop 브랜치**: 베타 버전들 존재 (1.1.6-beta.xxx, 2.0.7-beta.xxx, 1.1.7-beta.xxx)
- **main PR #247**: 존재하지만 아직 승인/머지 안됨
- **추가 changeset**: vue-pivottable과 plotly-renderer 변경

### 워크플로우 개선 사항
```bash
# 개선된 ensure_beta_version 함수
ensure_beta_version() {
  # 이미 베타 버전이면 타임스탬프 교체
  if [[ "$version" == *"-beta."* ]]; then
    base_version=$(echo "$version" | sed 's/-beta\..*//') 
    echo "${base_version}-beta.${timestamp}"
  else
    echo "${version}-beta.${timestamp}"
  fi
}
```

### 기대 결과
| 패키지 | 현재 | 예상 결과 |
|-------|------|----------|
| vue-pivottable | 1.1.6-beta.1750400546 | 1.1.7-beta.[NEW] |
| plotly-renderer | 2.0.7-beta.1750400990 | 2.0.8-beta.[NEW] |
| lazy-table-renderer | 1.1.7-beta.1750400990 | 1.1.7-beta.[NEW] (changeset 없음) |

### 테스트 목표
- [x] 베타 중복 방지 (1.1.7-beta.xxx-beta.yyy 형태 방지)
- [ ] 새로운 타임스탬프로 교체
- [ ] changeset이 있는 패키지만 버전 업데이트
- [ ] main PR #247 자동 업데이트
- [ ] peerDependencies 보호

### 중요성
이 시나리오는 **실제 개발 워크플로우에서 가장 흔한 상황**입니다:
1. 베타 릴리즈 후 main 승인 대기
2. 추가 개발 작업 및 changeset 추가
3. 베타 버전 업데이트