### PR TITLE
test: 수정된 베타 버전 증가 로직 테스트

### DIFF
--- a/.changeset/test-fixed-increment.md
+++ b/.changeset/test-fixed-increment.md
@@ -1,0 +1,17 @@
+---
+"vue-pivottable": patch
+"@vue-pivottable/plotly-renderer": patch
+---
+
+test: 수정된 베타 버전 증가 로직 테스트
+
+**수정된 워크플로우 검증:**
+
+1. changeset 실행 전 베타 접미사 제거
+2. changeset version으로 버전 증가 (1.1.6 → 1.1.7, 2.0.7 → 2.0.8)
+3. 증가된 버전에 베타 접미사 재적용
+
+**기대 결과:**
+- vue-pivottable: 1.1.6-beta.xxx → 1.1.7-beta.yyy
+- plotly-renderer: 2.0.7-beta.xxx → 2.0.8-beta.yyy  
+- lazy-table-renderer: 변경 없음 (changeset 제외)

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -68,7 +68,30 @@ jobs:
             fi
           done
           
-          # Apply changesets and consume them
+          # Remove beta suffixes temporarily so changeset can properly increment versions
+          echo "Temporarily removing beta suffixes for proper version increments..."
+          
+          # Remove beta suffix from main package
+          MAIN_VERSION=$(node -p "require('./package.json').version")
+          if [[ "$MAIN_VERSION" == *"-beta."* ]]; then
+            CLEAN_MAIN=$(echo "$MAIN_VERSION" | sed 's/-beta\.[0-9]*$//')
+            npm version $CLEAN_MAIN --no-git-tag-version
+            echo "✓ Main package: $MAIN_VERSION → $CLEAN_MAIN"
+          fi
+          
+          # Remove beta suffix from sub-packages
+          for pkg in packages/*/; do
+            if [ -d "$pkg" ] && [ -f "$pkg/package.json" ]; then
+              PKG_VERSION=$(node -p "require('./$pkg/package.json').version")
+              if [[ "$PKG_VERSION" == *"-beta."* ]]; then
+                CLEAN_PKG=$(echo "$PKG_VERSION" | sed 's/-beta\.[0-9]*$//')
+                cd "$pkg" && npm version $CLEAN_PKG --no-git-tag-version && cd ../..
+                echo "✓ $(basename $pkg): $PKG_VERSION → $CLEAN_PKG"
+              fi
+            fi
+          done
+          
+          # Apply changesets and consume them (now versions will properly increment)
           pnpm changeset version
           
           # Ensure beta versions on develop branch
@@ -89,44 +112,35 @@ jobs:
             fi
           }
           
-          # Check which packages were changed by changeset version
-          # Only apply beta timestamps to packages that were actually modified
-          echo "Checking which packages were modified by changeset..."
+          # Apply beta suffixes to packages processed by changeset
+          echo "Applying beta timestamps to packages processed by changeset..."
           
-          # Check main package
+          # Check main package - if no beta suffix, it was processed by changeset
           NEW_MAIN=$(node -p "require('./package.json').version")
-          if [ "$ORIGINAL_MAIN" != "$NEW_MAIN" ] || [[ "$NEW_MAIN" != *"-beta."* ]]; then
-            BETA_MAIN=$(update_beta_timestamp "$NEW_MAIN" "$TIMESTAMP")
-            if [ "$NEW_MAIN" != "$BETA_MAIN" ]; then
-              npm version $BETA_MAIN --no-git-tag-version
-              CHANGED_PACKAGES="vue-pivottable"
-              echo "✓ Updated vue-pivottable: $NEW_MAIN → $BETA_MAIN"
-            else
-              echo "✓ vue-pivottable already has correct beta version: $NEW_MAIN"
-            fi
+          if [[ "$NEW_MAIN" != *"-beta."* ]]; then
+            BETA_MAIN="${NEW_MAIN}-beta.${TIMESTAMP}"
+            npm version $BETA_MAIN --no-git-tag-version
+            CHANGED_PACKAGES="vue-pivottable"
+            echo "✓ Updated vue-pivottable: $NEW_MAIN → $BETA_MAIN"
           else
-            echo "✓ vue-pivottable unchanged: $NEW_MAIN"
+            echo "✓ vue-pivottable already has beta suffix: $NEW_MAIN"
           fi
           
-          # Check sub-packages
+          # Check sub-packages - if no beta suffix, they were processed by changeset
           for pkg in packages/*/; do
             if [ -d "$pkg" ] && [ -f "$pkg/package.json" ]; then
               cd "$pkg"
               PKG_NAME=$(basename "$pkg")
               NEW_VERSION=$(node -p "require('./package.json').version")
               
-              # Only update if package was changed by changeset OR doesn't have beta suffix
-              if [ "${ORIGINAL_VERSIONS[$PKG_NAME]}" != "$NEW_VERSION" ] || [[ "$NEW_VERSION" != *"-beta."* ]]; then
-                BETA_VERSION=$(update_beta_timestamp "$NEW_VERSION" "$TIMESTAMP")
-                if [ "$NEW_VERSION" != "$BETA_VERSION" ]; then
-                  npm version $BETA_VERSION --no-git-tag-version
-                  CHANGED_PACKAGES="$CHANGED_PACKAGES $PKG_NAME"
-                  echo "✓ Updated $PKG_NAME: $NEW_VERSION → $BETA_VERSION"
-                else
-                  echo "✓ $PKG_NAME already has correct beta version: $NEW_VERSION"
-                fi
+              # If no beta suffix, it was processed by changeset, so add beta
+              if [[ "$NEW_VERSION" != *"-beta."* ]]; then
+                BETA_VERSION="${NEW_VERSION}-beta.${TIMESTAMP}"
+                npm version $BETA_VERSION --no-git-tag-version
+                CHANGED_PACKAGES="$CHANGED_PACKAGES $PKG_NAME"
+                echo "✓ Updated $PKG_NAME: $NEW_VERSION → $BETA_VERSION"
               else
-                echo "✓ $PKG_NAME unchanged: $NEW_VERSION"
+                echo "✓ $PKG_NAME already has beta suffix: $NEW_VERSION"
               fi
               cd -
             fi


### PR DESCRIPTION
## 🧪 베타 버전 증가 로직 수정 검증

이 PR은 수정된 워크플로우가 베타 상태에서 올바르게 버전을 증가시키는지 테스트합니다.

### 🔧 수정된 로직

1. **changeset 실행 전**: 베타 접미사 임시 제거
   - `1.1.6-beta.1750403068` → `1.1.6`
   - `2.0.7-beta.1750403068` → `2.0.7`

2. **changeset version 실행**: 정상적인 버전 증가
   - `1.1.6` → `1.1.7` 
   - `2.0.7` → `2.0.8`

3. **changeset 실행 후**: 증가된 버전에 베타 접미사 재적용
   - `1.1.7` → `1.1.7-beta.새타임스탬프`
   - `2.0.8` → `2.0.8-beta.새타임스탬프`

### 🎯 기대 결과

- ✅ vue-pivottable: `1.1.6-beta.1750403068` → `1.1.7-beta.새타임스탬프`
- ✅ plotly-renderer: `2.0.7-beta.1750403068` → `2.0.8-beta.새타임스탬프`  
- ✅ lazy-table-renderer: 변경 없음 (changeset에 포함되지 않음)
- ✅ peerDependencies 보호 (베타 버전으로 오염되지 않음)

### 🚀 이전 문제점

changeset이 베타 접미사가 있는 버전을 "프리릴리즈"로 인식해서 버전을 증가시키지 않고 접미사만 제거하는 문제가 있었습니다.

🤖 Generated with [Claude Code](https://claude.ai/code)