### PR TITLE
fix:prevent VDragAndDropCell from disappearing on missing attribute #177

### DIFF
--- a/src/components/pivottable-ui/VDragAndDropCell.vue
+++ b/src/components/pivottable-ui/VDragAndDropCell.vue
@@ -1,6 +1,6 @@
 <template>
   <Draggable
-    v-if="showDraggable && modelItems.length > 0"
+    v-if="showDraggable"
     tag="td"
     :list="modelItems"
     :group="{ name: 'shared', pull: true, put: true }"


### PR DESCRIPTION
VDragAndDropCell에 attribute가 없을 때 cell영역이 사라지는 버그 수정

- `<Draggable/>` 렌더링 조건에서 `modelItems.length > 0` 삭제