### PR TITLE
chore: PR #253에 대한 changeset 추가

### DIFF
--- a/.changeset/fix-drag-drop-cell-missing-attribute.md
+++ b/.changeset/fix-drag-drop-cell-missing-attribute.md
@@ -1,0 +1,8 @@
+---
+"vue-pivottable": patch
+---
+
+fix: VDragAndDropCell이 속성이 없을 때 사라지는 문제 수정
+
+- DragAndDropCell 컴포넌트에서 속성이 누락되었을 때 발생하는 문제 해결
+- 이슈 #177 수정


### PR DESCRIPTION
## Summary
PR #253이 changeset 없이 머지되어 베타 릴리즈 PR #247의 CI 체크가 실패하는 문제를 해결합니다.

## Changes
- VDragAndDropCell 속성 누락 시 사라지는 문제 수정에 대한 changeset 추가

## Context
- PR #253: fix:prevent VDragAndDropCell from disappearing on missing attribute #177
- 이 PR이 changeset 없이 머지되어 베타 릴리즈 PR의 "Check for changesets" 단계가 실패
- CI는 모든 변경사항에 대해 changeset을 요구함

## Test plan
1. 이 PR 머지 후 베타 릴리즈 PR #247의 CI 체크가 통과하는지 확인