### PR TITLE
chore: stable 릴리즈를 위한 changeset 추가

### DIFF
--- a/.changeset/stable-release-1-1-7.md
+++ b/.changeset/stable-release-1-1-7.md
@@ -1,0 +1,14 @@
+---
+"vue-pivottable": patch
+"@vue-pivottable/lazy-table-renderer": patch
+"@vue-pivottable/plotly-renderer": patch
+---
+
+chore: stable 버전 1.1.7 릴리즈
+
+베타 테스트가 완료되어 stable 버전으로 릴리즈합니다.
+
+### 포함된 변경사항
+- fix: rows/cols가 비어있을 때 Vue2와 동일하게 렌더링되도록 수정
+- fix: VDragAndDropCell이 속성이 없을 때 사라지는 문제 수정
+- fix: 베타 버전 관리 및 릴리즈 프로세스 개선


### PR DESCRIPTION
## Summary
main 브랜치의 GitHub Actions 실패를 해결하기 위해 changeset을 추가합니다.

## Problem
- main 브랜치에 베타 버전(`1.1.7-beta.1751879666`)이 머지됨
- Release 워크플로우가 `pnpm changeset publish`를 실행하지만 changeset이 없어서 실패
- npm 배포와 GitHub Release 생성이 불가능한 상태

## Solution
- stable 릴리즈를 위한 changeset 파일 추가
- 이 PR이 머지되면 Release 워크플로우가 정상적으로 실행되어:
  - 베타 버전이 stable 버전(1.1.7)으로 변경
  - npm에 stable 버전 배포
  - GitHub Release 생성

## Test plan
1. 이 PR 머지 후 Release 워크플로우가 성공적으로 실행되는지 확인
2. npm에 vue-pivottable@1.1.7이 latest 태그로 배포되는지 확인
3. GitHub Releases에 각 패키지의 stable 버전이 생성되는지 확인