### PR TITLE
chore: stable 릴리즈 준비를 위한 changeset 추가

### DIFF
--- a/.changeset/stable-release-preparation.md
+++ b/.changeset/stable-release-preparation.md
@@ -1,0 +1,14 @@
+---
+"vue-pivottable": patch
+"@vue-pivottable/lazy-table-renderer": patch
+"@vue-pivottable/plotly-renderer": patch
+---
+
+chore: stable 버전 1.1.7 릴리즈 준비
+
+베타 테스트가 완료되어 stable 버전으로 릴리즈 준비합니다.
+
+### 포함된 변경사항
+- fix: rows/cols가 비어있을 때 Vue2와 동일하게 렌더링되도록 수정
+- fix: VDragAndDropCell이 속성이 없을 때 사라지는 문제 수정
+- chore: 베타 버전 관리 및 릴리즈 프로세스 개선


### PR DESCRIPTION
## Summary
main 브랜치의 Release 워크플로우 실패를 해결하기 위해 changeset을 추가합니다.

## Context
1. develop과 main 브랜치가 동기화됨
2. main 브랜치의 Release 워크플로우가 changeset 부재로 실패
3. stable 버전 배포를 위한 changeset 필요

## Changes
- stable 릴리즈를 위한 changeset 파일 추가
- 모든 패키지(vue-pivottable, lazy-table-renderer, plotly-renderer)에 patch 버전 업데이트

## Expected Flow
1. 이 PR이 develop에 머지
2. 베타 버전 업데이트 및 새로운 베타 릴리즈 PR 생성/업데이트
3. 베타 릴리즈 PR이 main에 머지될 때 changeset이 포함되어 있음
4. Release 워크플로우가 정상적으로 실행되어 stable 버전 배포

## Test plan
- [ ] PR 머지 후 develop 브랜치에서 베타 릴리즈 생성 확인
- [ ] 베타 릴리즈 PR이 main으로 머지될 때 Release 워크플로우 성공 확인
- [ ] npm에 stable 버전(1.1.7) 배포 확인