### PR TITLE
fix: Remove develop sync step from release workflow

### DIFF
--- a/.changeset/remove-develop-sync.md
+++ b/.changeset/remove-develop-sync.md
@@ -1,0 +1,8 @@
+---
+"vue-pivottable": patch
+---
+
+fix: Release 워크플로우에서 develop 동기화 단계 제거
+
+- main 브랜치에서 stable 릴리즈 후 develop 브랜치와의 동기화 시 발생하는 버전 충돌 문제 해결
+- develop은 항상 베타 버전을 유지하고, main은 stable 버전만 유지하도록 워크플로우 개선

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,23 +201,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Sync with develop
-        if: steps.check-versions.outputs.has_beta == 'true'
-        run: |
-          # Configure git
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          
-          # Fetch latest develop
-          git fetch origin develop:develop
-          
-          # Merge release branch into develop
-          git checkout develop
-          git merge ${{ steps.create-release.outputs.release_branch }} --no-edit -m "chore: sync release ${{ steps.create-release.outputs.release_branch }} to develop"
-          git push origin develop
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Create PR to main
         if: steps.check-versions.outputs.has_beta == 'true'
         run: |


### PR DESCRIPTION
## Summary
- Removes the "Sync with develop" step from the release workflow to prevent version conflicts
- This step was causing merge conflicts between main (stable versions) and develop (beta versions)

## Changes
- Removed lines 204-219 from `.github/workflows/release.yml`
- Added changeset documentation

## Why this change is needed
The sync step was attempting to merge stable versions from main back into develop, which already has beta versions with higher timestamps. This created version conflicts that prevented successful releases.

## Test plan
- [ ] PR checks pass
- [ ] After merge, the next release workflow should complete without sync errors