### PR TITLE
fix: export all composables for external packages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,5 +7,7 @@ const Renderer: Record<string, Component> = {
   ...TableRenderer
 }
 
+export * from './composables'
+
 export { VuePivottable, VuePivottableUi, PivotUtilities, Renderer }
 export default { VuePivottable, VuePivottableUi, PivotUtilities, Renderer }


### PR DESCRIPTION
## Summary
- Export all composables from main index.ts to enable custom renderer development
- Resolves import errors in plotly-renderer and lazy-table-renderer packages
- No circular dependency issues detected

## Problem
External packages (`@vue-pivottable/plotly-renderer`, `@vue-pivottable/lazy-table-renderer`) were unable to import `useProvidePivotData` and `providePivotData` functions, causing build errors as reported in issue #270.

## Solution
Added `export * from './composables'` to src/index.ts to expose all composables for external use.

## Analysis
Conducted thorough circular dependency analysis:
- ✅ Helper modules have no external dependencies
- ✅ Composables only import from helper/types/utils (no component imports)  
- ✅ Components import composables in one direction only
- ✅ Build completes successfully without warnings

## Test plan
- [x] Build main package successfully
- [x] Verify no circular dependency warnings
- [x] Test plotly-renderer package can import required functions
- [x] Test lazy-table-renderer package can import required functions

🤖 Generated with [Claude Code](https://claude.ai/code)