### PR TITLE
chore: add changeset for composables export feature

### DIFF
--- a/.changeset/composables-export-patch.md
+++ b/.changeset/composables-export-patch.md
@@ -1,0 +1,11 @@
+---
+"vue-pivottable": patch
+---
+
+Export all composables for external packages to enable custom renderer development
+
+- Added `export * from './composables'` to main index.ts
+- Resolves import errors for `useProvidePivotData` and `providePivotData` in external packages
+- Enables plotly-renderer and lazy-table-renderer to properly import required functions
+- No circular dependency issues detected after thorough analysis
+- Maintains backward compatibility while improving extensibility


### PR DESCRIPTION
## Summary
Add changeset documentation for the composables export feature merged in PR #295

## Context
PR #295 was merged without a changeset file. This PR adds the required changeset to properly track the version change and document it in release notes.

## Changes
- Added `.changeset/composables-export-patch.md` file
- Documents the patch version update for exporting all composables

## Related
- Merged PR: #295
- Original issue: #270 (plotly-renderer import errors)

🤖 Generated with [Claude Code](https://claude.ai/code)